### PR TITLE
fix: Update console.log port to 5173

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,6 +97,6 @@ import { createAxiosSetup, createAppComponent, setupRouterMain, createPWAReadme 
     console.log(`\nNext steps:\n  cd ${projectName}\n  npm install\n  npm run dev`);
     
     if (isPWA) {
-        console.log(`\n📱 To test PWA:\n  npm run build\n  npm run preview\n  Open http://localhost:4173 and test install/offline features`);
+        console.log(`\n📱 To test PWA:\n  npm run build\n  npm run preview\n  Open http://localhost:5173 and test install/offline features`);
     }
 })();


### PR DESCRIPTION
Closes #18

## Description
This PR updates the port number in the `console.log` instruction message from `4173` to `5173`, as specified in the issue description. This ensures the correct URL is displayed when testing the PWA features.

## How to test
1. Run the script that triggers this `console.log`.
2. Verify that the URL displayed in the terminal is now `http://localhost:5173`.