### PR TITLE
Add react-i18next and Shadcn/ui as optional packages

### DIFF
--- a/lib/css-frameworks.js
+++ b/lib/css-frameworks.js
@@ -55,6 +55,24 @@ export const setupMUI = (projectPath) => {
     writeFile(mainPath, mainContent);
 };
 
+// List of available frameworks and packages
+export const frameworks = [
+    { name: "Tailwind", value: "Tailwind" },
+    { name: "Bootstrap (CDN)", value: "Bootstrap (CDN)" },
+    { name: "React Bootstrap", value: "React Bootstrap" },
+    { name: "MUI", value: "MUI" }
+];
+
+export const optionalPackages = [
+    { name: "Axios", value: "axios" },
+    { name: "React Icons", value: "react-icons" },
+    { name: "React Hook Form", value: "react-hook-form" },
+    { name: "Yup", value: "yup" },
+    { name: "Formik", value: "formik" },
+    { name: "Moment.js", value: "moment" },
+    { name: "React i18next", value: "react-i18next" }
+];
+
 export const setupCSSFramework = (cssFramework, projectPath) => {
     const frameworkMap = {
         "Tailwind": () => setupTailwind(projectPath),

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -50,13 +50,88 @@ api.interceptors.response.use(
     writeFile(path.join(utilsDir, "axiosInstance.js"), axiosContent);
 };
 
-export const createAppComponent = (projectPath, projectName, isPWA) => {
+export const createI18nSetup = (projectPath) => {
+    const i18nContent = `
+import i18next from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+
+i18next
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources: {
+      en: {
+        translation: {
+          welcome: 'Welcome to your Quickstart React app!',
+        },
+      },
+      es: {
+        translation: {
+          welcome: '¡Bienvenido a tu aplicación Quickstart React!',
+        },
+      },
+    },
+    fallbackLng: 'en',
+    debug: process.env.NODE_ENV === 'development',
+  });
+
+export default i18next;
+`;
+    writeFile(path.join(projectPath, "src", "i18n.js"), i18nContent);
+
+    const mainFile = fileExists(path.join(projectPath, "src/main.jsx")) ? "src/main.jsx" : "src/main.tsx";
+    const mainPath = path.join(projectPath, mainFile);
+    let mainContent = readFile(mainPath);
+    if (!mainContent.includes(`import './i18n';`)) {
+        mainContent = `import './i18n';\n` + mainContent;
+    }
+    writeFile(mainPath, mainContent);
+};
+
+export const setupShadcn = (projectPath) => {
+    run(`npm install tailwindcss @tailwindcss/vite postcss autoprefixer lucide-react`, projectPath);
+    run(`npx shadcn-ui@latest init`, projectPath);
+    run(`npx shadcn-ui@latest add button`, projectPath);
+
+    const viteConfigPath = path.join(projectPath, "vite.config.js");
+    let viteConfig = readFile(viteConfigPath);
+    viteConfig = `import tailwindcss from '@tailwindcss/vite'\n` + viteConfig;
+    viteConfig = viteConfig.replace(/plugins:\s*\[/, "plugins: [\n    tailwindcss(),");
+    writeFile(viteConfigPath, viteConfig);
+
+    writeFile(path.join(projectPath, "components.json"), `
+{
+  "style": "default",
+  "tailwind": {
+    "config": "tailwind.config.js",
+    "css": "src/index.css",
+    "baseColor": "slate",
+    "cssVariables": true
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/utils"
+  }
+}
+`);
+};
+
+export const createAppComponent = (projectPath, projectName, isPWA, cssFramework, packages) => {
     const appFile = fileExists(path.join(projectPath, "src/App.jsx"))
         ? path.join(projectPath, "src/App.jsx")
         : path.join(projectPath, "src/App.tsx");
 
-    const appContent = `${isPWA ? `import { usePWA } from './hooks/usePWA';\n\n` : ''}export default function App() {
-  ${isPWA ? `const { isInstallable, installApp, isOnline } = usePWA();\n\n  ` : ''}return (
+    const appContent = `
+${isPWA ? `import { usePWA } from './hooks/usePWA';\n` : ''}
+${packages.includes('i18n') ? `import { useTranslation } from 'react-i18next';\n` : ''}
+${packages.includes('shadcn') ? `import { Button } from '@/components/ui/button';\n` : ''}
+
+export default function App() {
+  ${isPWA ? `const { isInstallable, installApp, isOnline } = usePWA();\n` : ''}
+  ${packages.includes('i18n') ? `const { t } = useTranslation();\n` : ''}
+
+  return (
     <div
       style={{
         display: "flex",
@@ -78,13 +153,14 @@ export const createAppComponent = (projectPath, projectName, isPWA) => {
           fontWeight: 600,
         }}
       >
-        Welcome to{" "}
-        <span style={{ color: "#2563eb" }}>${projectName}</span> 🚀
+        ${packages.includes('i18n') ? `{t('welcome')}` : `Welcome to <span style={{ color: "#2563eb" }}>${projectName}</span> 🚀`}
       </h1>
       <p style={{ fontSize: "1.1rem", color: "#555", marginBottom: "2rem" }}>
         Your ${isPWA ? 'PWA is' : 'project is'} ready. Start building amazing things!
       </p>
       
+      ${packages.includes('shadcn') ? `<div style={{ marginTop: "1rem" }}><Button>Click Me</Button></div>` : ''}
+
       ${isPWA ? `<div style={{ display: "flex", flexDirection: "column", gap: "1rem", alignItems: "center" }}>
         <div style={{ 
           padding: "0.5rem 1rem", 
@@ -177,7 +253,9 @@ A modern React application${isPWA ? ' with Progressive Web App (PWA) capabilitie
 ${isPWA ? `- 📱 **PWA Ready** - Installable, offline-capable app
 - 🔄 **Auto-updates** - Service worker with auto-update functionality
 - 📊 **Caching Strategy** - Smart caching for better performance` : ''}
-${packages.length > 0 ? `- 📦 **Additional Packages**: ${packages.join(', ')}` : ''}
+${packages.includes('i18n') ? `- 🌐 **Internationalization** - Powered by react-i18next for multi-language support` : ''}
+${packages.includes('shadcn') ? `- 🎨 **Shadcn/ui** - Accessible, customizable UI components` : ''}
+${packages.length > 0 ? `- 📦 **Additional Packages**: ${packages.map(p => p === 'i18n' ? 'react-i18next' : p === 'shadcn' ? 'shadcn/ui' : p).join(', ')}` : ''}
 
 ## 📋 Prerequisites
 
@@ -219,13 +297,11 @@ ${isPWA ? `## 📱 PWA Features
 ### Installation
 - **Desktop**: Look for the install icon in the address bar or use the "Install App" button
 - **Mobile**: Use "Add to Home Screen" option in your browser menu
-
 ### Offline Support
 This app works offline thanks to service worker caching:
 - Static assets are cached automatically
 - API responses are cached with NetworkFirst strategy
 - Fallback pages for offline scenarios
-
 ### Testing PWA Features
 
 1. **Install Prompt Testing**:
@@ -234,18 +310,14 @@ This app works offline thanks to service worker caching:
    npm run build
    npm run preview
    \`\`\`
-
 2. **Service Worker Testing**:
    - Open DevTools → Application → Service Workers
    - Check if SW is registered and active
-
 3. **Offline Testing**:
    - Build and serve the app
    - Open DevTools → Network → check "Offline"
    - Refresh the page - it should still work
-
 ### PWA Asset Replacement
-
 ⚠️ **Important**: Replace the placeholder SVG icons with proper PNG icons:
 
 1. Replace these files in \`public/\` folder:
@@ -269,6 +341,55 @@ This app works offline thanks to service worker caching:
 - ⚠️ Test on actual devices
 - ⚠️ Test offline functionality
 
+` : ''}${packages.includes('i18n') ? `## 🌐 Internationalization
+
+Internationalization is enabled with **react-i18next**:
+
+- Configuration in \`src/i18n.js\`
+- Example usage in \`src/App.jsx\`:
+
+\`\`\`javascript
+import { useTranslation } from 'react-i18next';
+
+function App() {
+  const { t } = useTranslation();
+  return <h1>{t('welcome')}</h1>;
+}
+\`\`\`
+
+### Adding Languages
+Edit \`src/i18n.js\` to add more languages:
+
+\`\`\`javascript
+i18next.init({
+  resources: {
+    en: { translation: { welcome: 'Welcome' } },
+    es: { translation: { welcome: 'Bienvenido' } },
+    // Add more languages here
+  }
+});
+\`\`\`
+` : ''}${packages.includes('shadcn') ? `## 🎨 Shadcn/ui Components
+
+Shadcn/ui provides accessible, customizable UI components:
+
+- Components installed in \`src/components/ui/\`
+- Example usage in \`src/App.jsx\`:
+
+\`\`\`javascript
+import { Button } from '@/components/ui/button';
+
+function App() {
+  return <Button>Click Me</Button>;
+}
+\`\`\`
+
+### Adding More Components
+Run the following to add more components:
+
+\`\`\`bash
+npx shadcn-ui@latest add <component-name>
+\`\`\`
 ` : ''}## 📁 Project Structure
 
 \`\`\`
@@ -279,23 +400,23 @@ ${isPWA ? `│   ├── pwa-192x192.svg    # Replace with PNG
 │   └── apple-touch-icon.svg # Replace with PNG
 ` : ''}├── src/
 │   ├── components/        # Reusable components
-│   ├── pages/            # Page components
+${packages.includes('shadcn') ? `│   │   └── ui/           # Shadcn/ui components
+` : ''}│   ├── pages/            # Page components
 │   ├── hooks/            # Custom React hooks
 ${isPWA ? `│   │   └── usePWA.js      # PWA functionality hook
 ` : ''}│   ├── store/            # State management
 │   ├── utils/            # Utility functions
 ${packages.includes('axios') ? `│   │   └── axiosInstance.js # Axios configuration
+` : ''}${packages.includes('i18n') ? `│   │   └── i18n.js        # i18next configuration
 ` : ''}│   ├── assets/          # Static assets
 │   ├── App.jsx           # Main App component
 │   └── main.jsx          # Entry point
 ├── vite.config.js        # Vite configuration
-└── package.json
+${packages.includes('shadcn') ? `├── components.json       # Shadcn/ui configuration
+` : ''}└── package.json
 \`\`\`
-
 ## 🎨 Styling
-
 This project uses **${cssFramework}** for styling:
-
 ${cssFramework === 'Tailwind' ? `- Classes are available globally
 - Configuration in \`vite.config.js\`
 - Customize in \`src/index.css\`` : 
@@ -314,7 +435,7 @@ ${packages.includes('axios') ? `## 🌐 API Integration
 Axios is pre-configured in \`src/utils/axiosInstance.js\`:
 
 \`\`\`javascript
-import { api } from './utils/axiosInstance';
+import { api } from './utilsaxiosInstance';
 
 // GET request
 const data = await api.get('/users');
@@ -370,11 +491,10 @@ ${isPWA ? `1. **Replace PWA Icons**: Replace SVG placeholders with proper PNG ic
 3. **Configure API**: Set up your API endpoints if using Axios
 4. **Add State Management**: Implement Redux/Zustand if needed
 5. **Deploy**: Deploy to your preferred hosting service`}
-
+${packages.includes('i18n') ? `\n6. **Add Languages**: Extend i18n.js with more translations` : ''}
+${packages.includes('shadcn') ? `\n${packages.includes('i18n') ? '7' : '6'}. **Add UI Components**: Use 'npx shadcn-ui@latest add' to include more Shadcn/ui components` : ''}
 ---
-
 Built with ❤️ by harsh & Sameer using React + Vite${isPWA ? ' + PWA' : ''}
 `;
-
     writeFile(path.join(projectPath, "README.md"), readmeContent);
 };

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   },
   "homepage": "https://github.com/harshgupta20/quickstart-react#readme",
   "dependencies": {
-    "inquirer": "^9.2.7"
+    "inquirer": "^12.9.3"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -5,11 +5,13 @@
 ## ✨ Features
 - **Interactive Setup** — prompts you for project name, CSS framework, and optional packages
 - **CSS Framework Support** — Tailwind CSS, Bootstrap, or MUI (Material UI)
-- **Optional Packages** — easily add Axios, React Icons, React Hook Form, Yup, Formik, and Moment.js
+- **Optional Packages** — easily add Axios, React Icons, React Hook Form, Yup, Formik, Moment.js, i18next (internationalization), and shadcn/ui
 - **Automatic Folder Structure** — creates `components`, `pages`, `hooks`, `store`, `utils`, `assets` folders
 - **Boilerplate Ready** — replaces default Vite boilerplate with a clean welcome page
 - **Axios Setup** — pre-configured Axios instance if selected
 - **CSS Integration** — automatically configures your chosen CSS framework with Vite
+- **Internationalization** - supports multi-language apps with i18next
+- **Shadcn/ui Integration** - adds customizable UI components with shadcn/ui
 
 ## 📦 Installation
 You don’t need to install it globally — run it instantly with `npx`:
@@ -32,7 +34,7 @@ npx quickstart-react
 ```
 ? Enter project name: my-portfolio
 ? Choose a CSS framework: Tailwind
-? Select optional packages: Axios, React Icons
+? Select optional packages: Axios, React Icons , i18next (internationalization), shadcn/ui
 ```
 
 This will:
@@ -87,6 +89,10 @@ You can add these during setup:
 - **Yup** — schema validation
 - **Formik** — form management
 - **Moment.js** — date/time utilities
+- **i18next (internationalization)** - enables multi-language support with pre-configured i18n.js
+- **shadcn/ui** - customizable, accessible UI components with a sample button
+
+
 
 ## 🚀 Quick Start
 ```bash


### PR DESCRIPTION
**Enhancement**: Add i18next and shadcn/ui as Optional Packages

This PR adds support for `i18next (internationalization)` and `shadcn/ui` as optional packages to the quickstart-react CLI:
- Updated `index.js` to include these in the checkbox prompt and handle their setup.
- Added `createI18nSetup` and `setupShadcn` to `templates.js` for configuration.
- Tested locally to ensure compatibility with existing features. 
- updated Readme.md for these enhancement features 

**Benefits**:
- Enables internationalization for global reach.
- Provides a modern UI component library as an option.


Please review and let me know if adjustments are needed!

<img width="1109" height="176" alt="feature_pr" src="https://github.com/user-attachments/assets/4ac4078b-750a-491c-91a3-ab1024f5828f" />
