### PR TITLE
refactor: remove credit text

### DIFF
--- a/lib/templates.js
+++ b/lib/templates.js
@@ -373,7 +373,7 @@ ${isPWA ? `1. **Replace PWA Icons**: Replace SVG placeholders with proper PNG ic
 
 ---
 
-Built with ❤️ by harsh & Sameer using React + Vite${isPWA ? ' + PWA' : ''}
+Built using React + Vite${isPWA ? ' + PWA' : ''}
 `;
 
     writeFile(path.join(projectPath, "README.md"), readmeContent);


### PR DESCRIPTION
fixes #25 

- Removed credit text from templates.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated the generated README header text to a neutral “Built using React + Vite,” replacing the prior attribution. This change applies in two template locations and preserves the conditional “+ PWA” suffix when applicable. Affects newly generated READMEs only. No functional, logic, or control-flow changes were made, and no exported interfaces were modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->